### PR TITLE
Make http port configurable from the Docker commandline

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This is available for an Intel based System (e.g. Synology Docker) as well as an
 ## Running docker
 Choose for the fitting docker tag and run the server with the following parameters:
 
-```sudo docker run -p 3000:3000 --mount type=bind,source=/PATH_TO_LOCAL_CONFIG, target=/config --mount type=bind,source=/PATH_TO_LOCAL_LOG,target=/log jomjol/wasserzaehler:DOCKER_TAG```
+```sudo docker run -p 3000:3000 -e WASSERZAEHLER_HTTP_PORT=3000 --mount type=bind,source=/PATH_TO_LOCAL_CONFIG, target=/config --mount type=bind,source=/PATH_TO_LOCAL_LOG,target=/log jomjol/wasserzaehler:DOCKER_TAG```
 
 #### Paramters
 | Parameter | 	Meaning  | Example |
@@ -34,6 +34,8 @@ Choose for the fitting docker tag and run the server with the following paramete
 | DOCKER_TAG | Docker tag for the correct docker version | ```raspi-latest``` |
 
 The config and the log directory can be empty at the very first start. They will be loaded with a default configuratio, that can be modified afterwards.
+
+If you want to run the HTTP server on a port other than 3000, replace all three occurrences in the commandline with the desired port number.
 
 ## Changelog - lastest version
 ##### 5.0.0 (2019-12-28)

--- a/code/wasseruhr.py
+++ b/code/wasseruhr.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
 
     wasserzaehler = lib.ZaehlerstandClass.Zaehlerstand()
 
-    PORT = 3000
+    PORT = os.getenv("WASSERZAEHLER_HTTP_PORT", 3000)
     with socketserver.TCPServer(("", PORT), SimpleHTTPRequestHandler) as httpd:
         print("Wasserzaehler is serving at port", PORT)
         httpd.serve_forever()


### PR DESCRIPTION
Hallo und ein Gutes Neues Jahr!

this pull request makes the http port number more flexible: Instead of using the fixed port 3000 it is now possible to set any port number for the http server on the command line.

This change allows anybody to use multiple instances of Wasserzaehler on one host (e.g. one instance for a water meter and a second instance for an electric energy meter) or to use Wasserzaehler on the same host as Grafana (which also uses port 3000 by default)